### PR TITLE
refactor: remove javascript height on section & replace with grid layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,8 +10,8 @@ import { SectionConnections } from "./section-connections";
 
 const RootIndexPage: React.FC = () => {
 	return (
-		<div className="flex flex-col h-screen font-nunito">
-			<div className="flex grow w-full">
+		<div className="w-screen grid grid-cols-1 [grid-template-rows:minmax(0,1fr)_max-content] h-screen font-nunito">
+			<main className="flex grow w-full">
 				<SectionConnections />
 				<SectionAbout />
 				<SectionExperience />
@@ -21,7 +21,7 @@ const RootIndexPage: React.FC = () => {
 				<Section className="bg-red-100" />
 				<Section className="bg-red-200" />
 				<Section className="bg-red-300" />
-			</div>
+			</main>
 			<footer className="py-8 px-16 bg-black-200 text-white-100 shrink-0 text-lg">
 				<span>
 					Copyright © <InlineLink href="/">Aries Clark</InlineLink>, {new Date().getFullYear()}

--- a/src/app/section.tsx
+++ b/src/app/section.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { atom, useAtom } from "jotai";
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef } from "react";
 import { twMerge } from "tailwind-merge";
 
 export type SectionProps = React.ComponentProps<"section"> & {
@@ -39,13 +39,6 @@ export const Section: React.FC<SectionProps> = (props) => {
 	}, [focusedSection, defaultFocus]);
 
 	const expandable = !!labelIcon;
-
-	const [footerHeight, setFooterHeight] = useState(0);
-	useEffect(() => {
-		if (typeof document === "undefined") return;
-		setFooterHeight(document.querySelector("footer")?.getBoundingClientRect().height ?? 0);
-	}, []);
-
 	return (
 		<section
 			{...elementProps}
@@ -58,9 +51,6 @@ export const Section: React.FC<SectionProps> = (props) => {
 				focused && focusClassName,
 				focused ? "shrink-0 w-100 " : "w-screen-1/9 min-w-0"
 			)}
-			style={{
-				height: `calc(100vh - ${footerHeight}px)`
-			}}
 			onFocus={({ currentTarget }) => {
 				if (!expandable) return;
 				setFocusedSection(currentTarget);


### PR DESCRIPTION
# DEMO
![image](https://user-images.githubusercontent.com/39814328/199935089-bbb8f0bc-ddf3-42a1-bd22-c64ec57c17af.png)

# TLDR
* Removed JavaScript height calculation on `<Section />`
* Swapped main content container to be a `main` instead of `div`
* Added Grid layout on main content

# Additional information
none.